### PR TITLE
Fixed errors when running on macOS 10.13.3

### DIFF
--- a/restic-runner
+++ b/restic-runner
@@ -304,7 +304,10 @@ function init {
 
 # * Args
 
-while [ "$#" -gt 0 ]
+args=$(getopt -n "$0" -o dh -l debug,repo:,set:,tag:,help,added,modified,removed -- "$@") || exit 1
+eval set -- "$args"
+
+while true
 do
     case "$1" in
         -d|--debug)
@@ -338,8 +341,9 @@ do
         --removed)
             removed=true
             ;;
-        *)
+        --)
             # Remaining args
+            shift
             command="$1"
             shift
             rest=("$@")

--- a/restic-runner
+++ b/restic-runner
@@ -59,7 +59,7 @@ Options
 EOF
 }
 function log {
-    echo "LOG ($(date --rfc-3339=seconds)): $@" >&2
+    echo "LOG ($(date "+%Y-%m-%d %H:%M:%S")): $@" >&2
 }
 
 function cleanup {
@@ -145,8 +145,9 @@ function human_duration {
     # $2 should be the later timestamp.  Timestamps should be strings
     # in any form that GNU date accepts.
 
-    local ts1=$(date +%s --date "$1")
-    local ts2=$(date +%s --date "$2")
+    local ts1=$1
+    local ts2=$2
+
     local difference=$(( $ts2 - $ts1 ))
 
     local hours=$(bc <<<"$difference / 60 / 60")
@@ -303,10 +304,7 @@ function init {
 
 # * Args
 
-args=$(getopt -n "$0" -o dh -l debug,repo:,set:,tag:,help,added,modified,removed -- "$@") || exit 1
-eval set -- "$args"
-
-while true
+while [ "$#" -gt 0 ]
 do
     case "$1" in
         -d|--debug)
@@ -340,9 +338,8 @@ do
         --removed)
             removed=true
             ;;
-        --)
+        *)
             # Remaining args
-            shift
             command="$1"
             shift
             rest=("$@")
@@ -396,7 +393,7 @@ type $command &>/dev/null || die "No such command: $command"
 # du.  Restic outputs its own duration, so there's no reason to
 # duplicate that, but it might be useful to know how much extra time
 # is taken by running du before and after.
-date_before=$(date)
+date_before=$(date +%s)
 du_enabled && du_before=$(repo_du)
 
 # Run command (backup, forget, prune, etc.)
@@ -404,7 +401,7 @@ $command || die "$command failed."
 
 # Log after command
 du_enabled && du_after=$(repo_du)
-date_after=$(date)
+date_after=$(date +%s)
 duration=$(human_duration "$date_before" "$date_after")
 
 if du_enabled


### PR DESCRIPTION
I ran into several errors when running on macOS 10.13.3 with Apple's command line development tools installed. Most of the errors were due to non-available parameters for date. Also getopt and the while loop. With these changes I have been able to backup without error on a daily basis. I've also successfully tested "command unlock" and "expire".