### PR TITLE
Support custom config dir through environment variable

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,7 +17,7 @@
 :END:
 
 1.  Put the =restic-runner= script in your =PATH=.
-2.  Make the directory =~/.config/backup/restic= (or a path of your choosing after changing the =config_dir= default variable in the script).
+2.  Make the directory =~/.config/backup/restic= (or a path of your choosing after changing the =config_dir= default variable in the script or setting the RESTIC_RUNNER_CONFIG_DIR environment variable).
 
 *** MacOS
 

--- a/restic-runner
+++ b/restic-runner
@@ -20,7 +20,7 @@
 
 # * Defaults
 
-config_dir=~/.config/backup/restic
+config_dir=${RESTIC_RUNNER_CONFIG_DIR:-$HOME/.config/backup/restic}
 
 # * Variables
 


### PR DESCRIPTION
This replaces https://github.com/alphapapa/restic-runner/pull/20

Allow setting config dir through environment variable _RESTIC_RUNNER_CONFIG_DIR_