### PR TITLE
Support setting a custom hostname for the backups

### DIFF
--- a/README.org
+++ b/README.org
@@ -55,6 +55,7 @@ It may also *define* these variables:
 
 +  =du=: Set to =true= to report the repo size and difference after running a Restic command.  This should only be enabled for local repos (e.g. not SFTP ones).
 +  =keep_policy=: A Bash array containing a list of =--keep-X= options.
++  =RESTIC_HOSTNAME=: A custom hostname to use for your backups - defaults to the hostname of the machine
 
 Example:
 

--- a/restic-runner
+++ b/restic-runner
@@ -163,6 +163,15 @@ function tag {
     fi
 }
 
+function hostname {
+    # Echo "--hostname HOSTNAME" if RESTIC_HOSTNAME is set, otherwise nothing.
+
+    if [[ ! -z "$RESTIC_HOSTNAME" ]]
+    then
+        echo "--host $RESTIC_HOSTNAME"
+    fi
+}	
+
 function snapshot-ids {
     # Return list of snapshot IDs
 
@@ -275,6 +284,7 @@ function backup {
            --one-file-system \
            --exclude-caches \
            $(exclude_if_present) \
+           $(hostname) \
            --exclude-file "$exclude_file" \
            --tag "$tag" \
            "${include_paths[@]}"


### PR DESCRIPTION
allow setting HOSTNAME for the backups,

this is useful if using `restic-runner` in a containerized / kubernetes environment where the hostname of the pod will change regularly so to keep the backups hostname consistent 